### PR TITLE
Update on upgrading liquid-staking-program with anchor-0.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,6 +1813,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 2.34.0",
+ "dynsigner",
  "log",
  "solana-clap-utils",
  "solana-cli-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "marinade-finance"
 version = "0.1.0"
-source = "git+https://github.com/marinade-finance/liquid-staking-program.git?tag=anchor-0.27-no-api-changes#2584c89aa20b66b5c408f6c8b19d4719a073b236"
+source = "git+https://github.com/marinade-finance/liquid-staking-program.git?branch=anchor-0.27#1bd5133d3198c0af05a0952d1ca8cd0d1e19fad6"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "marinade-finance"
 version = "0.1.0"
-source = "git+https://github.com/marinade-finance/liquid-staking-program.git?branch=anchor-0.27#1bd5133d3198c0af05a0952d1ca8cd0d1e19fad6"
+source = "git+https://github.com/marinade-finance/liquid-staking-program.git?branch=mainnet#1bd5133d3198c0af05a0952d1ca8cd0d1e19fad6"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/libs/dynsigner/src/lib.rs
+++ b/libs/dynsigner/src/lib.rs
@@ -30,8 +30,6 @@ impl Signer for DynSigner {
     }
 }
 
-
-
 /// Keypair or Pubkey depending, could be one of that based on parameters of the CLI command.
 /// For --print-only we want to permit to pass only pubkey not the keypair in real.
 #[derive(Debug, Clone)]
@@ -52,6 +50,13 @@ impl PubkeyOrSigner {
         match self {
             PubkeyOrSigner::Pubkey(_) => None,
             PubkeyOrSigner::Signer(keypair) => Some(keypair.clone()),
+        }
+    }
+
+    pub fn use_signer(&self) -> Option<&Arc<dyn Signer>> {
+        match self {
+            PubkeyOrSigner::Pubkey(_) => None,
+            PubkeyOrSigner::Signer(keypair) => Some(keypair),
         }
     }
 }

--- a/libs/dynsigner/src/lib.rs
+++ b/libs/dynsigner/src/lib.rs
@@ -60,3 +60,36 @@ impl PubkeyOrSigner {
         }
     }
 }
+
+impl From<PubkeyOrSigner> for Arc<dyn Signer> {
+    fn from(value: PubkeyOrSigner) -> Self {
+        match value {
+            PubkeyOrSigner::Pubkey(_) => panic!("Cannot convert PubkeyOrSigner::Pubkey to Signer"),
+            PubkeyOrSigner::Signer(keypair) => keypair,
+        }
+    }
+}
+
+impl Into<PubkeyOrSigner> for Arc<dyn Signer> {
+    fn into(self) -> PubkeyOrSigner {
+        PubkeyOrSigner::Signer(self)
+    }
+}
+
+impl Into<PubkeyOrSigner> for &Arc<dyn Signer> {
+    fn into(self) -> PubkeyOrSigner {
+        PubkeyOrSigner::Signer(self.clone())
+    }
+}
+
+impl From<PubkeyOrSigner> for Pubkey {
+    fn from(value: PubkeyOrSigner) -> Self {
+        value.pubkey()
+    }
+}
+
+impl Into<PubkeyOrSigner> for Pubkey {
+    fn into(self) -> PubkeyOrSigner {
+        PubkeyOrSigner::Pubkey(self)
+    }
+}

--- a/libs/dynsigner/src/lib.rs
+++ b/libs/dynsigner/src/lib.rs
@@ -29,3 +29,29 @@ impl Signer for DynSigner {
         self.0.is_interactive()
     }
 }
+
+
+
+/// Keypair or Pubkey depending, could be one of that based on parameters of the CLI command.
+/// For --print-only we want to permit to pass only pubkey not the keypair in real.
+#[derive(Debug, Clone)]
+pub enum PubkeyOrSigner {
+    Pubkey(Pubkey),
+    Signer(Arc<dyn Signer>),
+}
+
+impl PubkeyOrSigner {
+    pub fn pubkey(&self) -> Pubkey {
+        match self {
+            PubkeyOrSigner::Pubkey(pubkey) => *pubkey,
+            PubkeyOrSigner::Signer(keypair) => keypair.pubkey(),
+        }
+    }
+
+    pub fn try_as_signer(&self) -> Option<Arc<dyn Signer>> {
+        match self {
+            PubkeyOrSigner::Pubkey(_) => None,
+            PubkeyOrSigner::Signer(keypair) => Some(keypair.clone()),
+        }
+    }
+}

--- a/libs/marinade-client-rs/Cargo.toml
+++ b/libs/marinade-client-rs/Cargo.toml
@@ -13,7 +13,7 @@ spl-token = { version = "3.5.0", features = ["no-entrypoint"] }
 spl-associated-token-account  = { version = "1.1.3", features = ["no-entrypoint"] }
 log = "0.4.18"
 solana-client = "1.14.18"
-marinade-finance = { git = "https://github.com/marinade-finance/liquid-staking-program.git", branch = "anchor-0.27" }
+marinade-finance = { git = "https://github.com/marinade-finance/liquid-staking-program.git", branch = "mainnet" }
 dynsigner = { path = "../dynsigner" }
 anchor-lang = "0.27.0"
 anchor-client = "0.27.0"

--- a/libs/marinade-client-rs/Cargo.toml
+++ b/libs/marinade-client-rs/Cargo.toml
@@ -13,7 +13,7 @@ spl-token = { version = "3.5.0", features = ["no-entrypoint"] }
 spl-associated-token-account  = { version = "1.1.3", features = ["no-entrypoint"] }
 log = "0.4.18"
 solana-client = "1.14.18"
-marinade-finance = { git = "https://github.com/marinade-finance/liquid-staking-program.git", tag = "anchor-0.27-no-api-changes" }
+marinade-finance = { git = "https://github.com/marinade-finance/liquid-staking-program.git", branch = "anchor-0.27" }
 dynsigner = { path = "../dynsigner" }
 anchor-lang = "0.27.0"
 anchor-client = "0.27.0"

--- a/libs/marinade-client-rs/src/marinade/builder.rs
+++ b/libs/marinade-client-rs/src/marinade/builder.rs
@@ -7,7 +7,11 @@ use crate::marinade::instructions::{
     stake_reserve, update_active, update_deactivated, withdraw_stake_account,
 };
 use crate::marinade::rpc_marinade::RpcMarinade;
+use crate::marinade::verifiers::{
+    verify_admin_authority, verify_manager_authority, verify_pause_authority,
+};
 use anchor_client::RequestBuilder;
+use dynsigner::PubkeyOrSigner;
 use marinade_finance::instructions::{ChangeAuthorityData, ConfigMarinadeParams};
 use marinade_finance::state::Fee;
 use solana_sdk::pubkey::Pubkey;
@@ -18,15 +22,15 @@ use std::sync::Arc;
 pub trait MarinadeRequestBuilder<'a, C> {
     fn add_validator(
         &'a self,
-        validator_manager_authority: &'a Arc<dyn Signer>,
+        validator_manager_authority: &'a PubkeyOrSigner,
         validator_vote: Pubkey,
         score: u32,
-        rent_payer: &'a Arc<dyn Signer>,
+        rent_payer: &'a PubkeyOrSigner,
     ) -> anyhow::Result<RequestBuilder<C>>;
 
     fn set_validator_score(
         &'a self,
-        validator_manager_authority: &'a Arc<dyn Signer>,
+        validator_manager_authority: &'a PubkeyOrSigner,
         validator_vote: Pubkey,
         validator_index: u32,
         score: u32,
@@ -34,13 +38,13 @@ pub trait MarinadeRequestBuilder<'a, C> {
 
     fn config_validator_system(
         &'a self,
-        validator_manager_authority: &'a Arc<dyn Signer>,
+        validator_manager_authority: &'a PubkeyOrSigner,
         extra_runs: u32,
     ) -> anyhow::Result<RequestBuilder<C>>;
 
     fn emergency_unstake(
         &'a self,
-        validator_manager_authority: &'a Arc<dyn Signer>,
+        validator_manager_authority: &'a PubkeyOrSigner,
         stake_account: Pubkey,
         stake_index: u32,
         validator_index: u32,
@@ -48,36 +52,36 @@ pub trait MarinadeRequestBuilder<'a, C> {
 
     fn remove_validator(
         &'a self,
-        validator_manager_authority: &'a Arc<dyn Signer>,
+        validator_manager_authority: &'a PubkeyOrSigner,
         validator_vote: Pubkey,
         validator_index: u32,
     ) -> anyhow::Result<RequestBuilder<C>>;
 
     fn add_liquidity(
         &'a self,
-        transfer_from: &'a Arc<dyn Signer>,
+        transfer_from: &'a PubkeyOrSigner,
         mint_to: Pubkey,
         lamports: u64,
     ) -> anyhow::Result<RequestBuilder<C>>;
 
     fn change_authority(
         &'a self,
-        admin_authority: &'a Arc<dyn Signer>,
+        admin_authority: &'a PubkeyOrSigner,
         params: ChangeAuthorityData,
     ) -> anyhow::Result<RequestBuilder<C>>;
 
     fn deactivate_stake(
         &'a self,
         stake_account: Pubkey,
-        split_stake_account: &'a Arc<dyn Signer>,
-        split_stake_rent_payer: &'a Arc<dyn Signer>,
+        split_stake_account: &'a PubkeyOrSigner,
+        split_stake_rent_payer: &'a PubkeyOrSigner,
         stake_index: u32,
         validator_index: u32,
     ) -> anyhow::Result<RequestBuilder<C>>;
 
     fn deposit(
         &'a self,
-        transfer_from: &'a Arc<dyn Signer>,
+        transfer_from: &'a PubkeyOrSigner,
         mint_to: Pubkey,
         lamports: u64,
     ) -> anyhow::Result<RequestBuilder<C>>;
@@ -85,21 +89,21 @@ pub trait MarinadeRequestBuilder<'a, C> {
     fn deposit_stake_account(
         &'a self,
         stake_account: Pubkey,
-        stake_authority: &'a Arc<dyn Signer>,
+        stake_authority: &'a PubkeyOrSigner,
         mint_to: Pubkey,
         validator_index: u32,
         validator_vote: Pubkey,
-        rent_payer: &'a Arc<dyn Signer>,
+        rent_payer: &'a PubkeyOrSigner,
     ) -> anyhow::Result<RequestBuilder<C>>;
 
     fn partial_unstake(
         &'a self,
-        validator_manager_authority: &'a Arc<dyn Signer>,
+        validator_manager_authority: &'a PubkeyOrSigner,
         stake_account: Pubkey,
         stake_index: u32,
         validator_index: u32,
-        split_stake_account: &'a Arc<dyn Signer>,
-        split_stake_rent_payer: &'a Arc<dyn Signer>,
+        split_stake_account: &'a PubkeyOrSigner,
+        split_stake_rent_payer: &'a PubkeyOrSigner,
         desired_amount: u64,
     ) -> anyhow::Result<RequestBuilder<C>>;
 
@@ -119,7 +123,7 @@ pub trait MarinadeRequestBuilder<'a, C> {
     fn liquid_unstake(
         &'a self,
         get_msol_from: Pubkey,
-        get_msol_from_authority: &'a Arc<dyn Signer>,
+        get_msol_from_authority: &'a PubkeyOrSigner,
         transfer_sol_to: Pubkey,
         msol_amount: u64,
     ) -> anyhow::Result<RequestBuilder<C>>;
@@ -136,7 +140,7 @@ pub trait MarinadeRequestBuilder<'a, C> {
     fn remove_liquidity(
         &'a self,
         burn_from: Pubkey,
-        burn_from_authority: &'a Arc<dyn Signer>,
+        burn_from_authority: &'a PubkeyOrSigner,
         transfer_sol_to: Pubkey,
         transfer_msol_to: Pubkey,
         tokens: u64,
@@ -144,7 +148,7 @@ pub trait MarinadeRequestBuilder<'a, C> {
 
     fn config_lp(
         &'a self,
-        admin_authority: &'a Arc<dyn Signer>,
+        admin_authority: &'a PubkeyOrSigner,
         min_fee: Option<Fee>,
         max_fee: Option<Fee>,
         liquidity_target: Option<u64>,
@@ -153,7 +157,7 @@ pub trait MarinadeRequestBuilder<'a, C> {
 
     fn config_marinade(
         &'a self,
-        admin_authority: &'a Arc<dyn Signer>,
+        admin_authority: &'a PubkeyOrSigner,
         params: ConfigMarinadeParams,
     ) -> anyhow::Result<RequestBuilder<C>>;
 
@@ -161,8 +165,8 @@ pub trait MarinadeRequestBuilder<'a, C> {
         &'a self,
         validator_index: u32,
         validator_vote: Pubkey,
-        stake_account: &'a Arc<dyn Signer>,
-        rent_payer: &'a Arc<dyn Signer>,
+        stake_account: &'a PubkeyOrSigner,
+        rent_payer: &'a PubkeyOrSigner,
     ) -> anyhow::Result<RequestBuilder<C>>;
 
     fn update_active(
@@ -181,7 +185,7 @@ pub trait MarinadeRequestBuilder<'a, C> {
     fn order_unstake(
         &'a self,
         burn_msol_from: Pubkey,
-        burn_msol_from_authority: &'a Arc<dyn Signer>,
+        burn_msol_from_authority: &'a PubkeyOrSigner,
         msol_amount: u64,
         ticket_account: Pubkey,
     ) -> anyhow::Result<RequestBuilder<C>>;
@@ -194,21 +198,21 @@ pub trait MarinadeRequestBuilder<'a, C> {
 
     fn emergency_pause(
         &'a self,
-        pause_authority: &'a Arc<dyn Signer>,
+        pause_authority: &'a PubkeyOrSigner,
     ) -> anyhow::Result<RequestBuilder<C>>;
 
     fn emergency_resume(
         &'a self,
-        pause_authority: &'a Arc<dyn Signer>,
+        pause_authority: &'a PubkeyOrSigner,
     ) -> anyhow::Result<RequestBuilder<C>>;
 
     fn redelegate(
         &'a self,
         stake_account: Pubkey,
-        split_stake_account: &'a Arc<dyn Signer>,
-        split_stake_rent_payer: &'a Arc<dyn Signer>,
+        split_stake_account: &'a PubkeyOrSigner,
+        split_stake_rent_payer: &'a PubkeyOrSigner,
         dest_validator_account: Pubkey, // dest_validator_vote
-        redelegate_stake_account: &'a Arc<dyn Signer>,
+        redelegate_stake_account: &'a PubkeyOrSigner,
         stake_index: u32,
         source_validator_index: u32,
         dest_validator_index: u32,
@@ -218,9 +222,9 @@ pub trait MarinadeRequestBuilder<'a, C> {
         &'a self,
         stake_account: Pubkey,
         burn_msol_from: Pubkey,
-        burn_msol_authority: &'a Arc<dyn Signer>, // delegated or owner
-        split_stake_account: &'a Arc<dyn Signer>,
-        split_stake_rent_payer: &'a Arc<dyn Signer>,
+        burn_msol_authority: &'a PubkeyOrSigner, // delegated or owner
+        split_stake_account: &'a PubkeyOrSigner,
+        split_stake_rent_payer: &'a PubkeyOrSigner,
         validator_index: u32,
         stake_index: u32,
         msol_amount: u64,
@@ -231,198 +235,253 @@ pub trait MarinadeRequestBuilder<'a, C> {
 impl<'a, C: Deref<Target = impl Signer> + Clone> MarinadeRequestBuilder<'a, C> for RpcMarinade<C> {
     fn add_validator(
         &'a self,
-        validator_manager_authority: &'a Arc<dyn Signer>,
+        validator_manager_authority: &'a PubkeyOrSigner,
         validator_vote: Pubkey,
         score: u32,
-        rent_payer: &'a Arc<dyn Signer>,
+        rent_payer: &'a PubkeyOrSigner,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        add_validator(
+        verify_manager_authority(&self.state, &validator_manager_authority.pubkey())?;
+        let mut builder = add_validator(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            validator_manager_authority,
-            validator_vote,
+            &validator_vote,
             score,
-            rent_payer,
-        )
+            &rent_payer.pubkey(),
+        )?;
+        if let Some(signer) = validator_manager_authority.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        if let Some(signer) = rent_payer.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn set_validator_score(
         &'a self,
-        validator_manager_authority: &'a Arc<dyn Signer>,
+        validator_manager_authority: &'a PubkeyOrSigner,
         validator_vote: Pubkey,
         validator_index: u32,
         score: u32,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        set_validator_score(
+        verify_manager_authority(&self.state, &validator_manager_authority.pubkey())?;
+        let mut builder = set_validator_score(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            validator_manager_authority,
-            validator_vote,
+            &validator_vote,
             validator_index,
             score,
-        )
+        )?;
+        if let Some(signer) = validator_manager_authority.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn config_validator_system(
         &'a self,
-        validator_manager_authority: &'a Arc<dyn Signer>,
+        validator_manager_authority: &'a PubkeyOrSigner,
         extra_runs: u32,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        config_validator_system(
+        verify_manager_authority(&self.state, &validator_manager_authority.pubkey())?;
+        let mut builder = config_validator_system(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            validator_manager_authority,
             extra_runs,
-        )
+        )?;
+        if let Some(signer) = validator_manager_authority.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn emergency_unstake(
         &'a self,
-        validator_manager_authority: &'a Arc<dyn Signer>,
+        validator_manager_authority: &'a PubkeyOrSigner,
         stake_account: Pubkey,
         stake_index: u32,
         validator_index: u32,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        emergency_unstake(
+        verify_manager_authority(&self.state, &validator_manager_authority.pubkey())?;
+        let mut builder = emergency_unstake(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            validator_manager_authority,
-            stake_account,
+            &stake_account,
             stake_index,
             validator_index,
-        )
+        )?;
+        if let Some(signer) = validator_manager_authority.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn remove_validator(
         &'a self,
-        validator_manager_authority: &'a Arc<dyn Signer>,
+        validator_manager_authority: &'a PubkeyOrSigner,
         validator_vote: Pubkey,
         validator_index: u32,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        remove_validator(
+        verify_manager_authority(&self.state, &validator_manager_authority.pubkey())?;
+        let mut builder = remove_validator(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            validator_manager_authority,
-            validator_vote,
+            &validator_vote,
             validator_index,
-        )
+        )?;
+        if let Some(signer) = validator_manager_authority.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn add_liquidity(
         &'a self,
-        transfer_from: &'a Arc<dyn Signer>,
+        transfer_from: &'a PubkeyOrSigner,
         mint_to: Pubkey,
         lamports: u64,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        add_liquidity(
+        let mut builder = add_liquidity(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            transfer_from,
-            mint_to,
+            &transfer_from.pubkey(),
+            &mint_to,
             lamports,
-        )
+        )?;
+        if let Some(signer) = transfer_from.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn change_authority(
         &'a self,
-        admin_authority: &'a Arc<dyn Signer>,
+        admin_authority: &'a PubkeyOrSigner,
         params: ChangeAuthorityData,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        change_authority(
-            &self.program,
-            self.instance_pubkey,
-            &self.state,
-            admin_authority,
-            params,
-        )
+        verify_admin_authority(&self.state, &admin_authority.pubkey())?;
+        let mut builder =
+            change_authority(&self.program, &self.instance_pubkey, &self.state, params)?;
+        if let Some(signer) = admin_authority.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn deactivate_stake(
         &'a self,
         stake_account: Pubkey,
-        split_stake_account: &'a Arc<dyn Signer>,
-        split_stake_rent_payer: &'a Arc<dyn Signer>,
+        split_stake_account: &'a PubkeyOrSigner,
+        split_stake_rent_payer: &'a PubkeyOrSigner,
         stake_index: u32,
         validator_index: u32,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        deactivate_stake(
+        let mut builder = deactivate_stake(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            stake_account,
-            split_stake_account,
-            split_stake_rent_payer,
+            &stake_account,
+            &split_stake_account.pubkey(),
+            &split_stake_rent_payer.pubkey(),
             stake_index,
             validator_index,
-        )
+        )?;
+        if let Some(signer) = split_stake_account.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        if let Some(signer) = split_stake_rent_payer.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn deposit(
         &'a self,
-        transfer_from: &'a Arc<dyn Signer>,
+        transfer_from: &'a PubkeyOrSigner,
         mint_to: Pubkey,
         lamports: u64,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        deposit(
+        let mut builder = deposit(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            transfer_from,
-            mint_to,
+            &transfer_from.pubkey(),
+            &mint_to,
             lamports,
-        )
+        )?;
+        if let Some(signer) = transfer_from.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn deposit_stake_account(
         &'a self,
         stake_account: Pubkey,
-        stake_authority: &'a Arc<dyn Signer>,
+        stake_authority: &'a PubkeyOrSigner,
         mint_to: Pubkey,
         validator_index: u32,
         validator_vote: Pubkey,
-        rent_payer: &'a Arc<dyn Signer>,
+        rent_payer: &'a PubkeyOrSigner,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        deposit_stake_account(
+        let mut builder = deposit_stake_account(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            stake_account,
-            stake_authority,
-            mint_to,
+            &stake_account,
+            &stake_authority.pubkey(),
+            &mint_to,
             validator_index,
-            validator_vote,
-            rent_payer,
-        )
+            &validator_vote,
+            &rent_payer.pubkey(),
+        )?;
+        if let Some(signer) = stake_authority.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        if let Some(signer) = rent_payer.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn partial_unstake(
         &'a self,
-        validator_manager_authority: &'a Arc<dyn Signer>,
+        validator_manager_authority: &'a PubkeyOrSigner,
         stake_account: Pubkey,
         stake_index: u32,
         validator_index: u32,
-        split_stake_account: &'a Arc<dyn Signer>,
-        split_stake_rent_payer: &'a Arc<dyn Signer>,
+        split_stake_account: &'a PubkeyOrSigner,
+        split_stake_rent_payer: &'a PubkeyOrSigner,
         desired_amount: u64,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        partial_unstake(
+        verify_manager_authority(&self.state, &validator_manager_authority.pubkey())?;
+        let mut builder = partial_unstake(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            validator_manager_authority,
-            stake_account,
+            &stake_account,
             stake_index,
             validator_index,
-            split_stake_account,
-            split_stake_rent_payer,
+            &split_stake_account.pubkey(),
+            &split_stake_rent_payer.pubkey(),
             desired_amount,
-        )
+        )?;
+        if let Some(signer) = validator_manager_authority.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        if let Some(signer) = split_stake_account.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        if let Some(signer) = split_stake_rent_payer.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn initialize(
@@ -437,36 +496,41 @@ impl<'a, C: Deref<Target = impl Signer> + Clone> MarinadeRequestBuilder<'a, C> f
         liq_pool_msol_leg: Pubkey,
         data: marinade_finance::instructions::InitializeData,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        initialize(
+        Ok(initialize(
             &self.program,
-            state,
-            msol_mint,
-            operational_sol_account,
-            stake_list,
-            validator_list,
-            treasury_msol_account,
-            lp_mint,
-            liq_pool_msol_leg,
+            &state.pubkey(),
+            &msol_mint,
+            &operational_sol_account,
+            &stake_list,
+            &validator_list,
+            &treasury_msol_account,
+            &lp_mint,
+            &liq_pool_msol_leg,
             data,
-        )
+        )?
+        .signer(state.as_ref()))
     }
 
     fn liquid_unstake(
         &'a self,
         get_msol_from: Pubkey,
-        get_msol_from_authority: &'a Arc<dyn Signer>,
+        get_msol_from_authority: &'a PubkeyOrSigner,
         transfer_sol_to: Pubkey,
         msol_amount: u64,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        liquid_unstake(
+        let mut builder = liquid_unstake(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            get_msol_from,
-            get_msol_from_authority,
-            transfer_sol_to,
+            &get_msol_from,
+            &get_msol_from_authority.pubkey(),
+            &transfer_sol_to,
             msol_amount,
-        )
+        )?;
+        if let Some(signer) = get_msol_from_authority.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn merge_stakes(
@@ -477,88 +541,104 @@ impl<'a, C: Deref<Target = impl Signer> + Clone> MarinadeRequestBuilder<'a, C> f
         source_stake_index: u32,
         validator_index: u32,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        merge_stakes(
+        let builder = merge_stakes(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            destination_stake,
+            &destination_stake,
             destination_stake_index,
-            source_stake,
+            &source_stake,
             source_stake_index,
             validator_index,
-        )
+        )?;
+        Ok(builder)
     }
 
     fn remove_liquidity(
         &'a self,
         burn_from: Pubkey,
-        burn_from_authority: &'a Arc<dyn Signer>,
+        burn_from_authority: &'a PubkeyOrSigner,
         transfer_sol_to: Pubkey,
         transfer_msol_to: Pubkey,
         tokens: u64,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        remove_liquidity(
+        let mut builder = remove_liquidity(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            burn_from,
-            burn_from_authority,
-            transfer_sol_to,
-            transfer_msol_to,
+            &burn_from,
+            &burn_from_authority.pubkey(),
+            &transfer_sol_to,
+            &transfer_msol_to,
             tokens,
-        )
+        )?;
+        if let Some(signer) = burn_from_authority.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn config_lp(
         &'a self,
-        admin_authority: &'a Arc<dyn Signer>,
+        admin_authority: &'a PubkeyOrSigner,
         min_fee: Option<Fee>,
         max_fee: Option<Fee>,
         liquidity_target: Option<u64>,
         treasury_bp_cut: Option<Fee>,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        config_lp(
+        verify_admin_authority(&self.state, &admin_authority.pubkey())?;
+        let mut builder = config_lp(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            admin_authority,
             min_fee,
             max_fee,
             liquidity_target,
             treasury_bp_cut,
-        )
+        )?;
+        if let Some(signer) = admin_authority.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn config_marinade(
         &'a self,
-        admin_authority: &'a Arc<dyn Signer>,
+        admin_authority: &'a PubkeyOrSigner,
         params: ConfigMarinadeParams,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        config_marinade(
-            &self.program,
-            self.instance_pubkey,
-            &self.state,
-            admin_authority,
-            params,
-        )
+        verify_admin_authority(&self.state, &admin_authority.pubkey())?;
+        let mut builder =
+            config_marinade(&self.program, &self.instance_pubkey, &self.state, params)?;
+        if let Some(signer) = admin_authority.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn stake_reserve(
         &'a self,
         validator_index: u32,
         validator_vote: Pubkey,
-        stake_account: &'a Arc<dyn Signer>,
-        rent_payer: &'a Arc<dyn Signer>,
+        stake_account: &'a PubkeyOrSigner,
+        rent_payer: &'a PubkeyOrSigner,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        stake_reserve(
+        let mut builder = stake_reserve(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
             validator_index,
-            validator_vote,
-            stake_account,
-            rent_payer,
-        )
+            &validator_vote,
+            &stake_account.pubkey(),
+            &rent_payer.pubkey(),
+        )?;
+        if let Some(signer) = stake_account.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        if let Some(signer) = rent_payer.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn update_active(
@@ -569,9 +649,9 @@ impl<'a, C: Deref<Target = impl Signer> + Clone> MarinadeRequestBuilder<'a, C> f
     ) -> anyhow::Result<RequestBuilder<C>> {
         update_active(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            stake_account,
+            &stake_account,
             stake_index,
             validator_index,
         )
@@ -584,9 +664,9 @@ impl<'a, C: Deref<Target = impl Signer> + Clone> MarinadeRequestBuilder<'a, C> f
     ) -> anyhow::Result<RequestBuilder<C>> {
         update_deactivated(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            stake_account,
+            &stake_account,
             stake_index,
         )
     }
@@ -594,19 +674,23 @@ impl<'a, C: Deref<Target = impl Signer> + Clone> MarinadeRequestBuilder<'a, C> f
     fn order_unstake(
         &'a self,
         burn_msol_from: Pubkey,
-        burn_msol_from_authority: &'a Arc<dyn Signer>,
+        burn_msol_from_authority: &'a PubkeyOrSigner,
         msol_amount: u64,
         ticket_account: Pubkey,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        order_unstake(
+        let mut builder = order_unstake(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            burn_msol_from,
-            burn_msol_from_authority,
+            &burn_msol_from,
+            &burn_msol_from_authority.pubkey(),
             msol_amount,
-            ticket_account,
-        )
+            &ticket_account,
+        )?;
+        if let Some(signer) = burn_msol_from_authority.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn claim(
@@ -616,87 +700,107 @@ impl<'a, C: Deref<Target = impl Signer> + Clone> MarinadeRequestBuilder<'a, C> f
     ) -> anyhow::Result<RequestBuilder<C>> {
         claim(
             &self.program,
-            self.instance_pubkey,
-            ticket_account,
-            beneficiary,
+            &self.instance_pubkey,
+            &ticket_account,
+            &beneficiary,
         )
     }
 
     fn emergency_pause(
         &'a self,
-        pause_authority: &'a Arc<dyn Signer>,
+        pause_authority: &'a PubkeyOrSigner,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        emergency_pause(
-            &self.program,
-            self.instance_pubkey,
-            &self.state,
-            pause_authority,
-        )
+        verify_pause_authority(&self.state, &pause_authority.pubkey())?;
+        let mut builder = emergency_pause(&self.program, &self.instance_pubkey, &self.state)?;
+        if let Some(signer) = pause_authority.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn emergency_resume(
         &'a self,
-        pause_authority: &'a Arc<dyn Signer>,
+        pause_authority: &'a PubkeyOrSigner,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        emergency_resume(
-            &self.program,
-            self.instance_pubkey,
-            &self.state,
-            pause_authority,
-        )
+        verify_pause_authority(&self.state, &pause_authority.pubkey())?;
+        let mut builder = emergency_resume(&self.program, &self.instance_pubkey, &self.state)?;
+        if let Some(signer) = pause_authority.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn redelegate(
         &'a self,
         stake_account: Pubkey,
-        split_stake_account: &'a Arc<dyn Signer>,
-        split_stake_rent_payer: &'a Arc<dyn Signer>,
+        split_stake_account: &'a PubkeyOrSigner,
+        split_stake_rent_payer: &'a PubkeyOrSigner,
         dest_validator_account: Pubkey, // dest_validator_vote
-        redelegate_stake_account: &'a Arc<dyn Signer>,
+        redelegate_stake_account: &'a PubkeyOrSigner,
         stake_index: u32,
         source_validator_index: u32,
         dest_validator_index: u32,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        redelegate(
+        let mut builder = redelegate(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            stake_account,
-            split_stake_account,
-            split_stake_rent_payer,
-            dest_validator_account,
-            redelegate_stake_account,
+            &stake_account,
+            &split_stake_account.pubkey(),
+            &split_stake_rent_payer.pubkey(),
+            &dest_validator_account,
+            &redelegate_stake_account.pubkey(),
             stake_index,
             source_validator_index,
             dest_validator_index,
-        )
+        )?;
+        if let Some(signer) = split_stake_account.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        if let Some(signer) = split_stake_rent_payer.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        if let Some(signer) = redelegate_stake_account.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 
     fn withdraw_stake_account(
         &'a self,
         stake_account: Pubkey,
         burn_msol_from: Pubkey,
-        burn_msol_authority: &'a Arc<dyn Signer>, // delegated or owner
-        split_stake_account: &'a Arc<dyn Signer>,
-        split_stake_rent_payer: &'a Arc<dyn Signer>,
+        burn_msol_authority: &'a PubkeyOrSigner, // delegated or owner
+        split_stake_account: &'a PubkeyOrSigner,
+        split_stake_rent_payer: &'a PubkeyOrSigner,
         validator_index: u32,
         stake_index: u32,
         msol_amount: u64,
         beneficiary: Pubkey,
     ) -> anyhow::Result<RequestBuilder<C>> {
-        withdraw_stake_account(
+        let mut builder = withdraw_stake_account(
             &self.program,
-            self.instance_pubkey,
+            &self.instance_pubkey,
             &self.state,
-            stake_account,
-            burn_msol_from,
-            burn_msol_authority,
-            split_stake_account,
-            split_stake_rent_payer,
+            &stake_account,
+            &burn_msol_from,
+            &burn_msol_authority.pubkey(),
+            &split_stake_account.pubkey(),
+            &split_stake_rent_payer.pubkey(),
             validator_index,
             stake_index,
             msol_amount,
-            beneficiary,
-        )
+            &beneficiary,
+        )?;
+        if let Some(signer) = burn_msol_authority.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        if let Some(signer) = split_stake_account.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        if let Some(signer) = split_stake_rent_payer.use_signer() {
+            builder = builder.signer(signer.as_ref());
+        }
+        Ok(builder)
     }
 }

--- a/libs/marinade-client-rs/src/marinade/builder.rs
+++ b/libs/marinade-client-rs/src/marinade/builder.rs
@@ -161,7 +161,7 @@ pub trait MarinadeRequestBuilder<'a, C> {
         &'a self,
         validator_index: u32,
         validator_vote: Pubkey,
-        stake_account: Pubkey,
+        stake_account: &'a Arc<dyn Signer>,
         rent_payer: &'a Arc<dyn Signer>,
     ) -> anyhow::Result<RequestBuilder<C>>;
 
@@ -547,7 +547,7 @@ impl<'a, C: Deref<Target = impl Signer> + Clone> MarinadeRequestBuilder<'a, C> f
         &'a self,
         validator_index: u32,
         validator_vote: Pubkey,
-        stake_account: Pubkey,
+        stake_account: &'a Arc<dyn Signer>,
         rent_payer: &'a Arc<dyn Signer>,
     ) -> anyhow::Result<RequestBuilder<C>> {
         stake_reserve(

--- a/libs/marinade-client-rs/src/marinade/instructions.rs
+++ b/libs/marinade-client-rs/src/marinade/instructions.rs
@@ -592,7 +592,7 @@ pub fn stake_reserve<'a, C: Deref<Target = impl Signer> + Clone>(
     state: &State,
     validator_index: u32,
     validator_vote: Pubkey,
-    stake_account: Pubkey,
+    stake_account: &'a Arc<dyn Signer>,
     rent_payer: &'a Arc<dyn Signer>,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
     Ok(program
@@ -603,7 +603,7 @@ pub fn stake_reserve<'a, C: Deref<Target = impl Signer> + Clone>(
             stake_list: *state.stake_system.stake_list_address(),
             validator_vote,
             reserve_pda: State::find_reserve_address(&state_pubkey).0,
-            stake_account,
+            stake_account: stake_account.pubkey(),
             stake_deposit_authority: StakeSystem::find_stake_deposit_authority(&state_pubkey).0,
             rent_payer: rent_payer.pubkey(),
             clock: sysvar::clock::id(),
@@ -615,7 +615,8 @@ pub fn stake_reserve<'a, C: Deref<Target = impl Signer> + Clone>(
             stake_program: stake::program::ID,
         })
         .args(marinade_finance_instruction::StakeReserve { validator_index })
-        .signer(rent_payer.as_ref()))
+        .signer(rent_payer.as_ref())
+        .signer(stake_account.as_ref()))
 }
 
 pub fn update_active<'a, C: Deref<Target = impl Signer> + Clone>(

--- a/libs/marinade-client-rs/src/marinade/instructions.rs
+++ b/libs/marinade-client-rs/src/marinade/instructions.rs
@@ -1,7 +1,4 @@
 #![allow(clippy::too_many_arguments)]
-use crate::marinade::verifiers::{
-    verify_admin_authority, verify_manager_authority, verify_pause_authority,
-};
 use anchor_client::{Program, RequestBuilder};
 use marinade_finance::state::liq_pool::LiqPool;
 use marinade_finance::state::stake_system::StakeSystem;
@@ -14,100 +11,87 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signer::Signer;
 use solana_sdk::{stake, system_program, sysvar};
 use std::ops::Deref;
-use std::sync::Arc;
 
 pub fn add_validator<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &'a State,
-    validator_manager_authority: &'a Arc<dyn Signer>,
-    validator_vote: Pubkey,
+    validator_vote: &Pubkey,
     score: u32,
-    rent_payer: &'a Arc<dyn Signer>,
+    rent_payer: &Pubkey,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
-    verify_manager_authority(state, validator_manager_authority.pubkey())?;
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::AddValidator {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             manager_authority: state.validator_system.manager_authority,
             validator_list: *state.validator_system.validator_list_address(),
-            validator_vote,
+            validator_vote: *validator_vote,
             duplication_flag: ValidatorRecord::find_duplication_flag(
-                &state_pubkey,
+                &state_pubkey.clone(),
                 &validator_vote,
             )
             .0,
-            rent_payer: rent_payer.pubkey(),
+            rent_payer: rent_payer.clone(),
             clock: sysvar::clock::id(),
             rent: sysvar::rent::id(),
             system_program: system_program::ID,
         })
-        .args(marinade_finance_instruction::AddValidator { score })
-        .signer(validator_manager_authority.as_ref())
-        .signer(rent_payer.as_ref()))
+        .args(marinade_finance_instruction::AddValidator { score }))
 }
 
 pub fn config_validator_system<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &'a State,
-    validator_manager_authority: &'a Arc<dyn Signer>,
     extra_runs: u32,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
-    verify_manager_authority(state, validator_manager_authority.pubkey())?;
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::ConfigValidatorSystem {
-            state: state_pubkey,
+            state: *state_pubkey,
             manager_authority: state.validator_system.manager_authority,
         })
-        .args(marinade_finance_instruction::ConfigValidatorSystem { extra_runs })
-        .signer(validator_manager_authority.as_ref()))
+        .args(marinade_finance_instruction::ConfigValidatorSystem { extra_runs }))
 }
 
 pub fn set_validator_score<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    validator_manager_authority: &'a Arc<dyn Signer>,
-    validator_vote: Pubkey,
+    validator_vote: &Pubkey,
     validator_index: u32,
     score: u32,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
-    verify_manager_authority(state, validator_manager_authority.pubkey())?;
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::SetValidatorScore {
-            state: state_pubkey,
+            state: *state_pubkey,
             manager_authority: state.validator_system.manager_authority,
             validator_list: *state.validator_system.validator_list_address(),
         })
         .args(marinade_finance_instruction::SetValidatorScore {
             score,
             index: validator_index,
-            validator_vote,
-        })
-        .signer(validator_manager_authority.as_ref()))
+            validator_vote: validator_vote.clone(),
+        }))
 }
 
 pub fn remove_validator<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    validator_manager_authority: &'a Arc<dyn Signer>,
-    validator_vote: Pubkey,
+    validator_vote: &Pubkey,
     index: u32,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
-    verify_manager_authority(state, validator_manager_authority.pubkey())?;
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::RemoveValidator {
-            state: state_pubkey,
+            state: *state_pubkey,
             manager_authority: state.validator_system.manager_authority,
             validator_list: *state.validator_system.validator_list_address(),
             duplication_flag: ValidatorRecord::find_duplication_flag(
-                &state_pubkey,
+                &state_pubkey.clone(),
                 &validator_vote,
             )
             .0,
@@ -115,29 +99,26 @@ pub fn remove_validator<'a, C: Deref<Target = impl Signer> + Clone>(
         })
         .args(marinade_finance_instruction::RemoveValidator {
             index,
-            validator_vote,
-        })
-        .signer(validator_manager_authority.as_ref()))
+            validator_vote: validator_vote.clone(),
+        }))
 }
 
 pub fn emergency_unstake<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    validator_manager_authority: &'a Arc<dyn Signer>,
-    stake_account: Pubkey,
+    stake_account: &Pubkey,
     stake_index: u32,
     validator_index: u32,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
-    verify_manager_authority(state, validator_manager_authority.pubkey())?;
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::EmergencyUnstake {
-            state: state_pubkey,
+            state: *state_pubkey,
             validator_manager_authority: state.validator_system.manager_authority,
             validator_list: *state.validator_system.validator_list_address(),
             stake_list: *state.stake_system.stake_list_address(),
-            stake_account,
+            stake_account: *stake_account,
             stake_deposit_authority: StakeSystem::find_stake_deposit_authority(&state_pubkey).0,
             clock: sysvar::clock::id(),
             stake_program: stake::program::id(),
@@ -145,74 +126,69 @@ pub fn emergency_unstake<'a, C: Deref<Target = impl Signer> + Clone>(
         .args(marinade_finance_instruction::EmergencyUnstake {
             stake_index,
             validator_index,
-        })
-        .signer(validator_manager_authority.as_ref()))
+        }))
 }
 
 pub fn add_liquidity<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    transfer_from: &'a Arc<dyn Signer>,
-    mint_to: Pubkey,
+    transfer_from: &Pubkey,
+    mint_to: &Pubkey,
     lamports: u64,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::AddLiquidity {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             lp_mint: state.liq_pool.lp_mint,
             lp_mint_authority: LiqPool::find_lp_mint_authority(&state_pubkey).0,
             liq_pool_msol_leg: state.liq_pool.msol_leg,
             liq_pool_sol_leg_pda: LiqPool::find_sol_leg_address(&state_pubkey).0,
-            transfer_from: transfer_from.pubkey(),
-            mint_to,
+            transfer_from: *transfer_from,
+            mint_to: *mint_to,
             system_program: system_program::ID,
             token_program: spl_token::ID,
         })
-        .args(marinade_finance_instruction::AddLiquidity { lamports })
-        .signer(transfer_from.as_ref()))
+        .args(marinade_finance_instruction::AddLiquidity { lamports }))
 }
 
 pub fn change_authority<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    admin_authority: &'a Arc<dyn Signer>,
     data: marinade_finance::instructions::ChangeAuthorityData,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
-    verify_admin_authority(state, admin_authority.pubkey())?;
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::ChangeAuthority {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             admin_authority: state.admin_authority,
         })
-        .args(marinade_finance_instruction::ChangeAuthority { data })
-        .signer(admin_authority.as_ref()))
+        .args(marinade_finance_instruction::ChangeAuthority { data }))
 }
 
 pub fn deactivate_stake<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    stake_account: Pubkey,
-    split_stake_account: &'a Arc<dyn Signer>,
-    split_stake_rent_payer: &'a Arc<dyn Signer>,
+    stake_account: &Pubkey,
+    split_stake_account: &Pubkey,
+    split_stake_rent_payer: &Pubkey,
     stake_index: u32,
     validator_index: u32,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::DeactivateStake {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             reserve_pda: State::find_reserve_address(&state_pubkey).0,
             validator_list: *state.validator_system.validator_list_address(),
             stake_list: *state.stake_system.stake_list_address(),
-            stake_account,
+            stake_account: *stake_account,
             stake_deposit_authority: StakeSystem::find_stake_deposit_authority(&state_pubkey).0,
-            split_stake_account: split_stake_account.pubkey(),
-            split_stake_rent_payer: split_stake_rent_payer.pubkey(),
+            split_stake_account: *split_stake_account,
+            split_stake_rent_payer: *split_stake_rent_payer,
             clock: sysvar::clock::id(),
             rent: sysvar::rent::id(),
             epoch_schedule: sysvar::epoch_schedule::id(),
@@ -223,65 +199,62 @@ pub fn deactivate_stake<'a, C: Deref<Target = impl Signer> + Clone>(
         .args(marinade_finance_instruction::DeactivateStake {
             stake_index,
             validator_index,
-        })
-        .signer(split_stake_account.as_ref())
-        .signer(split_stake_rent_payer.as_ref()))
+        }))
 }
 
 pub fn deposit<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    transfer_from: &'a Arc<dyn Signer>,
-    mint_to: Pubkey,
+    transfer_from: &Pubkey,
+    mint_to: &Pubkey,
     lamports: u64,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::Deposit {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             msol_mint: state.msol_mint,
             liq_pool_sol_leg_pda: LiqPool::find_sol_leg_address(&state_pubkey).0,
             liq_pool_msol_leg: state.liq_pool.msol_leg,
             liq_pool_msol_leg_authority: LiqPool::find_msol_leg_authority(&state_pubkey).0,
             reserve_pda: State::find_reserve_address(&state_pubkey).0,
-            transfer_from: transfer_from.pubkey(),
-            mint_to,
+            transfer_from: *transfer_from,
+            mint_to: *mint_to,
             msol_mint_authority: State::find_msol_mint_authority(&state_pubkey).0,
             system_program: system_program::ID,
             token_program: spl_token::ID,
         })
-        .args(marinade_finance_instruction::Deposit { lamports })
-        .signer(transfer_from.as_ref()))
+        .args(marinade_finance_instruction::Deposit { lamports }))
 }
 
 pub fn deposit_stake_account<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    stake_account: Pubkey,
-    stake_authority: &'a Arc<dyn Signer>,
-    mint_to: Pubkey,
+    stake_account: &Pubkey,
+    stake_authority: &Pubkey,
+    mint_to: &Pubkey,
     validator_index: u32,
-    validator_vote: Pubkey,
-    rent_payer: &'a Arc<dyn Signer>,
+    validator_vote: &Pubkey,
+    rent_payer: &Pubkey,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::DepositStakeAccount {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             validator_list: *state.validator_system.validator_list_address(),
             stake_list: *state.stake_system.stake_list_address(),
-            stake_account,
-            stake_authority: stake_authority.pubkey(),
+            stake_account: *stake_account,
+            stake_authority: *stake_authority,
             duplication_flag: ValidatorRecord::find_duplication_flag(
-                &state_pubkey,
+                &state_pubkey.clone(),
                 &validator_vote,
             )
             .0,
-            rent_payer: rent_payer.pubkey(),
+            rent_payer: *rent_payer,
             msol_mint: state.msol_mint,
-            mint_to,
+            mint_to: *mint_to,
             msol_mint_authority: State::find_msol_mint_authority(&state_pubkey).0,
             clock: sysvar::clock::id(),
             rent: sysvar::rent::id(),
@@ -289,40 +262,38 @@ pub fn deposit_stake_account<'a, C: Deref<Target = impl Signer> + Clone>(
             token_program: spl_token::ID,
             stake_program: stake::program::ID,
         })
-        .args(marinade_finance_instruction::DepositStakeAccount { validator_index })
-        .signer(stake_authority.as_ref())
-        .signer(rent_payer.as_ref()))
+        .args(marinade_finance_instruction::DepositStakeAccount { validator_index }))
 }
 
 pub fn withdraw_stake_account<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    stake_account: Pubkey,
-    burn_msol_from: Pubkey,
-    burn_msol_authority: &'a Arc<dyn Signer>, // delegated or owner
-    split_stake_account: &'a Arc<dyn Signer>,
-    split_stake_rent_payer: &'a Arc<dyn Signer>,
+    stake_account: &Pubkey,
+    burn_msol_from: &Pubkey,
+    burn_msol_authority: &Pubkey, // delegated or owner
+    split_stake_account: &Pubkey,
+    split_stake_rent_payer: &Pubkey,
     validator_index: u32,
     stake_index: u32,
     msol_amount: u64,
-    beneficiary: Pubkey,
+    beneficiary: &Pubkey,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::WithdrawStakeAccount {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             msol_mint: state.msol_mint,
-            burn_msol_from,
-            burn_msol_authority: burn_msol_authority.pubkey(),
+            burn_msol_from: *burn_msol_from,
+            burn_msol_authority: *burn_msol_authority,
             treasury_msol_account: state.treasury_msol_account,
             validator_list: *state.validator_system.validator_list_address(),
             stake_list: *state.stake_system.stake_list_address(),
             stake_withdraw_authority: StakeSystem::find_stake_withdraw_authority(&state_pubkey).0,
             stake_deposit_authority: StakeSystem::find_stake_deposit_authority(&state_pubkey).0,
-            stake_account,
-            split_stake_account: split_stake_account.pubkey(),
-            split_stake_rent_payer: split_stake_rent_payer.pubkey(),
+            stake_account: *stake_account,
+            split_stake_account: *split_stake_account,
+            split_stake_rent_payer: *split_stake_rent_payer,
             clock: sysvar::clock::id(),
             system_program: system_program::ID,
             token_program: spl_token::ID,
@@ -332,38 +303,33 @@ pub fn withdraw_stake_account<'a, C: Deref<Target = impl Signer> + Clone>(
             stake_index,
             validator_index,
             msol_amount,
-            beneficiary,
-        })
-        .signer(burn_msol_authority.as_ref())
-        .signer(split_stake_account.as_ref())
-        .signer(split_stake_rent_payer.as_ref()))
+            beneficiary: *beneficiary,
+        }))
 }
 
 pub fn partial_unstake<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    validator_manager_authority: &'a Arc<dyn Signer>,
-    stake_account: Pubkey,
+    stake_account: &Pubkey,
     stake_index: u32,
     validator_index: u32,
-    split_stake_account: &'a Arc<dyn Signer>,
-    split_stake_rent_payer: &'a Arc<dyn Signer>,
+    split_stake_account: &Pubkey,
+    split_stake_rent_payer: &Pubkey,
     desired_unstake_amount: u64,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
-    verify_manager_authority(state, validator_manager_authority.pubkey())?;
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::PartialUnstake {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             validator_manager_authority: state.validator_system.manager_authority,
             validator_list: *state.validator_system.validator_list_address(),
             stake_list: *state.stake_system.stake_list_address(),
-            stake_account,
+            stake_account: *stake_account,
             stake_deposit_authority: StakeSystem::find_stake_deposit_authority(&state_pubkey).0,
             reserve_pda: State::find_reserve_address(&state_pubkey).0,
-            split_stake_account: split_stake_account.pubkey(),
-            split_stake_rent_payer: split_stake_rent_payer.pubkey(),
+            split_stake_account: *split_stake_account,
+            split_stake_rent_payer: *split_stake_rent_payer,
             clock: sysvar::clock::id(),
             rent: sysvar::rent::id(),
             stake_history: sysvar::stake_history::id(),
@@ -374,91 +340,86 @@ pub fn partial_unstake<'a, C: Deref<Target = impl Signer> + Clone>(
             stake_index,
             validator_index,
             desired_unstake_amount,
-        })
-        .signer(split_stake_account.as_ref())
-        .signer(split_stake_rent_payer.as_ref())
-        .signer(validator_manager_authority.as_ref()))
+        }))
 }
 
 pub fn initialize<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state: &'a Arc<dyn Signer>,
-    msol_mint: Pubkey,
-    operational_sol_account: Pubkey,
-    stake_list: Pubkey,
-    validator_list: Pubkey,
-    treasury_msol_account: Pubkey,
-    lp_mint: Pubkey,
-    liq_pool_msol_leg: Pubkey,
+    state: &Pubkey,
+    msol_mint: &Pubkey,
+    operational_sol_account: &Pubkey,
+    stake_list: &Pubkey,
+    validator_list: &Pubkey,
+    treasury_msol_account: &Pubkey,
+    lp_mint: &Pubkey,
+    liq_pool_msol_leg: &Pubkey,
     data: marinade_finance::instructions::InitializeData,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::Initialize {
-            state: state.pubkey(),
-            reserve_pda: State::find_reserve_address(&state.pubkey()).0,
-            stake_list,
-            validator_list,
-            msol_mint,
-            operational_sol_account,
-            treasury_msol_account,
+            state: *state,
+            reserve_pda: State::find_reserve_address(&state).0,
+            stake_list: *stake_list,
+            validator_list: *validator_list,
+            msol_mint: *msol_mint,
+            operational_sol_account: *operational_sol_account,
+            treasury_msol_account: *treasury_msol_account,
             clock: sysvar::clock::id(),
             rent: sysvar::rent::id(),
             liq_pool: marinade_finance_accounts::LiqPoolInitialize {
-                lp_mint,
-                sol_leg_pda: LiqPool::find_sol_leg_address(&state.pubkey()).0,
-                msol_leg: liq_pool_msol_leg,
+                lp_mint: *lp_mint,
+                sol_leg_pda: LiqPool::find_sol_leg_address(&state).0,
+                msol_leg: *liq_pool_msol_leg,
             },
         })
-        .args(marinade_finance_instruction::Initialize { data })
-        .signer(state.as_ref()))
+        .args(marinade_finance_instruction::Initialize { data }))
 }
 
 pub fn liquid_unstake<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    get_msol_from: Pubkey,
-    get_msol_from_authority: &'a Arc<dyn Signer>,
-    transfer_sol_to: Pubkey,
+    get_msol_from: &Pubkey,
+    get_msol_from_authority: &Pubkey,
+    transfer_sol_to: &Pubkey,
     msol_amount: u64,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::LiquidUnstake {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             msol_mint: state.msol_mint,
             liq_pool_sol_leg_pda: LiqPool::find_sol_leg_address(&state_pubkey).0,
             liq_pool_msol_leg: state.liq_pool.msol_leg,
-            get_msol_from,
-            get_msol_from_authority: get_msol_from_authority.pubkey(),
-            transfer_sol_to,
+            get_msol_from: *get_msol_from,
+            get_msol_from_authority: *get_msol_from_authority,
+            transfer_sol_to: *transfer_sol_to,
             treasury_msol_account: state.treasury_msol_account,
             system_program: system_program::ID,
             token_program: spl_token::ID,
         })
-        .args(marinade_finance_instruction::LiquidUnstake { msol_amount })
-        .signer(get_msol_from_authority.as_ref()))
+        .args(marinade_finance_instruction::LiquidUnstake { msol_amount }))
 }
 
 pub fn merge_stakes<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    destination_stake: Pubkey,
+    destination_stake: &Pubkey,
     destination_stake_index: u32,
-    source_stake: Pubkey,
+    source_stake: &Pubkey,
     source_stake_index: u32,
     validator_index: u32,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::MergeStakes {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             stake_list: *state.stake_system.stake_list_address(),
             validator_list: *state.validator_system.validator_list_address(),
-            destination_stake,
-            source_stake,
+            destination_stake: *destination_stake,
+            source_stake: *source_stake,
             stake_deposit_authority: StakeSystem::find_stake_deposit_authority(&state_pubkey).0,
             stake_withdraw_authority: StakeSystem::find_stake_withdraw_authority(&state_pubkey).0,
             operational_sol_account: state.operational_sol_account,
@@ -475,13 +436,13 @@ pub fn merge_stakes<'a, C: Deref<Target = impl Signer> + Clone>(
 
 pub fn redelegate<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    stake_account: Pubkey,
-    split_stake_account: &'a Arc<dyn Signer>,
-    split_stake_rent_payer: &'a Arc<dyn Signer>,
-    dest_validator_account: Pubkey, // dest_validator_vote
-    redelegate_stake_account: &'a Arc<dyn Signer>,
+    stake_account: &Pubkey,
+    split_stake_account: &Pubkey,
+    split_stake_rent_payer: &Pubkey,
+    dest_validator_account: &Pubkey, // dest_validator_vote
+    redelegate_stake_account: &Pubkey,
     stake_index: u32,
     source_validator_index: u32,
     dest_validator_index: u32,
@@ -489,16 +450,16 @@ pub fn redelegate<'a, C: Deref<Target = impl Signer> + Clone>(
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::ReDelegate {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             validator_list: *state.validator_system.validator_list_address(),
             stake_list: *state.stake_system.stake_list_address(),
-            stake_account,
+            stake_account: *stake_account,
             stake_deposit_authority: StakeSystem::find_stake_deposit_authority(&state_pubkey).0,
             reserve_pda: State::find_reserve_address(&state_pubkey).0,
-            split_stake_account: split_stake_account.pubkey(),
-            split_stake_rent_payer: split_stake_rent_payer.pubkey(),
-            dest_validator_account,
-            redelegate_stake_account: redelegate_stake_account.pubkey(),
+            split_stake_account: *split_stake_account,
+            split_stake_rent_payer: *split_stake_rent_payer,
+            dest_validator_account: *dest_validator_account,
+            redelegate_stake_account: *redelegate_stake_account,
             clock: sysvar::clock::id(),
             stake_history: sysvar::stake_history::id(),
             stake_program: stake::program::ID,
@@ -514,48 +475,45 @@ pub fn redelegate<'a, C: Deref<Target = impl Signer> + Clone>(
 
 pub fn remove_liquidity<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    burn_from: Pubkey,
-    burn_from_authority: &'a Arc<dyn Signer>,
-    transfer_sol_to: Pubkey,
-    transfer_msol_to: Pubkey,
+    burn_from: &Pubkey,
+    burn_from_authority: &Pubkey,
+    transfer_sol_to: &Pubkey,
+    transfer_msol_to: &Pubkey,
     tokens: u64,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::RemoveLiquidity {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             lp_mint: state.liq_pool.lp_mint,
-            burn_from,
-            burn_from_authority: burn_from_authority.pubkey(), //owner acc is also token owner
-            transfer_sol_to,
-            transfer_msol_to,
+            burn_from: *burn_from,
+            burn_from_authority: *burn_from_authority, //owner acc is also token owner
+            transfer_sol_to: *transfer_sol_to,
+            transfer_msol_to: *transfer_msol_to,
             liq_pool_sol_leg_pda: LiqPool::find_sol_leg_address(&state_pubkey).0,
             liq_pool_msol_leg: state.liq_pool.msol_leg,
             liq_pool_msol_leg_authority: LiqPool::find_msol_leg_authority(&state_pubkey).0,
             system_program: system_program::ID,
             token_program: spl_token::ID,
         })
-        .args(marinade_finance_instruction::RemoveLiquidity { tokens })
-        .signer(burn_from_authority.as_ref()))
+        .args(marinade_finance_instruction::RemoveLiquidity { tokens }))
 }
 
 pub fn config_lp<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    admin_authority: &'a Arc<dyn Signer>,
     min_fee: Option<Fee>,
     max_fee: Option<Fee>,
     liquidity_target: Option<u64>,
     treasury_bp_cut: Option<Fee>,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
-    verify_admin_authority(state, admin_authority.pubkey())?;
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::ConfigLp {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             admin_authority: state.admin_authority,
         })
         .args(marinade_finance_instruction::ConfigLp {
@@ -565,47 +523,44 @@ pub fn config_lp<'a, C: Deref<Target = impl Signer> + Clone>(
                 liquidity_target,
                 treasury_cut: treasury_bp_cut,
             },
-        })
-        .signer(admin_authority.as_ref()))
+        }))
 }
 
 pub fn config_marinade<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    admin_authority: &'a Arc<dyn Signer>,
     params: marinade_finance::instructions::ConfigMarinadeParams,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
     Ok(program
         .request()
-        .accounts(marinade_finance_accounts::ConfigLp {
-            state: state_pubkey,
+        .accounts(marinade_finance_accounts::ConfigMarinade {
+            state: state_pubkey.clone(),
             admin_authority: state.admin_authority,
         })
-        .args(marinade_finance_instruction::ConfigMarinade { params })
-        .signer(admin_authority.as_ref()))
+        .args(marinade_finance_instruction::ConfigMarinade { params }))
 }
 
 pub fn stake_reserve<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
     validator_index: u32,
-    validator_vote: Pubkey,
-    stake_account: &'a Arc<dyn Signer>,
-    rent_payer: &'a Arc<dyn Signer>,
+    validator_vote: &Pubkey,
+    stake_account: &Pubkey,
+    rent_payer: &Pubkey,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::StakeReserve {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             validator_list: *state.validator_system.validator_list_address(),
             stake_list: *state.stake_system.stake_list_address(),
-            validator_vote,
+            validator_vote: *validator_vote,
             reserve_pda: State::find_reserve_address(&state_pubkey).0,
-            stake_account: stake_account.pubkey(),
+            stake_account: *stake_account,
             stake_deposit_authority: StakeSystem::find_stake_deposit_authority(&state_pubkey).0,
-            rent_payer: rent_payer.pubkey(),
+            rent_payer: *rent_payer,
             clock: sysvar::clock::id(),
             epoch_schedule: sysvar::epoch_schedule::ID,
             rent: sysvar::rent::id(),
@@ -614,16 +569,14 @@ pub fn stake_reserve<'a, C: Deref<Target = impl Signer> + Clone>(
             system_program: system_program::ID,
             stake_program: stake::program::ID,
         })
-        .args(marinade_finance_instruction::StakeReserve { validator_index })
-        .signer(rent_payer.as_ref())
-        .signer(stake_account.as_ref()))
+        .args(marinade_finance_instruction::StakeReserve { validator_index }))
 }
 
 pub fn update_active<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    stake_account: Pubkey,
+    stake_account: &Pubkey,
     stake_index: u32,
     validator_index: u32,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
@@ -631,9 +584,9 @@ pub fn update_active<'a, C: Deref<Target = impl Signer> + Clone>(
         .request()
         .accounts(marinade_finance_accounts::UpdateActive {
             common: marinade_finance_accounts::UpdateCommon {
-                state: state_pubkey,
+                state: state_pubkey.clone(),
                 stake_list: *state.stake_system.stake_list_address(),
-                stake_account,
+                stake_account: *stake_account,
                 stake_withdraw_authority: StakeSystem::find_stake_withdraw_authority(&state_pubkey)
                     .0,
                 reserve_pda: State::find_reserve_address(&state_pubkey).0,
@@ -655,18 +608,18 @@ pub fn update_active<'a, C: Deref<Target = impl Signer> + Clone>(
 
 pub fn update_deactivated<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    stake_account: Pubkey,
+    stake_account: &Pubkey,
     stake_index: u32,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::UpdateDeactivated {
             common: marinade_finance_accounts::UpdateCommon {
-                state: state_pubkey,
+                state: state_pubkey.clone(),
                 stake_list: *state.stake_system.stake_list_address(),
-                stake_account,
+                stake_account: *stake_account,
                 stake_withdraw_authority: StakeSystem::find_stake_withdraw_authority(&state_pubkey)
                     .0,
                 reserve_pda: State::find_reserve_address(&state_pubkey).0,
@@ -684,19 +637,19 @@ pub fn update_deactivated<'a, C: Deref<Target = impl Signer> + Clone>(
         .args(marinade_finance_instruction::UpdateDeactivated { stake_index }))
 }
 
-pub fn claim<C: Deref<Target = impl Signer> + Clone>(
-    program: &Program<C>,
-    state_pubkey: Pubkey,
-    ticket_account: Pubkey,
-    transfer_sol_to: Pubkey,
-) -> anyhow::Result<RequestBuilder<C>> {
+pub fn claim<'a, C: Deref<Target = impl Signer> + Clone>(
+    program: &'a Program<C>,
+    state_pubkey: &Pubkey,
+    ticket_account: &Pubkey,
+    transfer_sol_to: &Pubkey,
+) -> anyhow::Result<RequestBuilder<'a, C>> {
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::Claim {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             reserve_pda: State::find_reserve_address(&state_pubkey).0,
-            ticket_account,
-            transfer_sol_to,
+            ticket_account: *ticket_account,
+            transfer_sol_to: *transfer_sol_to,
             system_program: system_program::ID,
             clock: sysvar::clock::ID,
         })
@@ -705,59 +658,52 @@ pub fn claim<C: Deref<Target = impl Signer> + Clone>(
 
 pub fn order_unstake<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    burn_msol_from: Pubkey,
-    burn_msol_from_authority: &'a Arc<dyn Signer>, // delegated or owner
+    burn_msol_from: &Pubkey,
+    burn_msol_from_authority: &Pubkey, // delegated or owner
     msol_amount: u64,
-    new_ticket_account: Pubkey,
+    new_ticket_account: &Pubkey,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::OrderUnstake {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             msol_mint: state.msol_mint,
-            burn_msol_from,
-            burn_msol_authority: burn_msol_from_authority.pubkey(),
-            new_ticket_account,
+            burn_msol_from: *burn_msol_from,
+            burn_msol_authority: *burn_msol_from_authority,
+            new_ticket_account: *new_ticket_account,
             token_program: spl_token::ID,
             clock: sysvar::clock::ID,
             rent: sysvar::rent::ID,
         })
-        .args(marinade_finance_instruction::OrderUnstake { msol_amount })
-        .signer(burn_msol_from_authority.as_ref()))
+        .args(marinade_finance_instruction::OrderUnstake { msol_amount }))
 }
 
 pub fn emergency_pause<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    pause_authority: &'a Arc<dyn Signer>,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
-    verify_pause_authority(state, pause_authority.pubkey())?;
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::EmergencyPause {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             pause_authority: state.pause_authority,
         })
-        .args(marinade_finance_instruction::Pause {})
-        .signer(pause_authority.as_ref()))
+        .args(marinade_finance_instruction::Pause {}))
 }
 
 pub fn emergency_resume<'a, C: Deref<Target = impl Signer> + Clone>(
     program: &'a Program<C>,
-    state_pubkey: Pubkey,
+    state_pubkey: &Pubkey,
     state: &State,
-    pause_authority: &'a Arc<dyn Signer>,
 ) -> anyhow::Result<RequestBuilder<'a, C>> {
-    verify_pause_authority(state, pause_authority.pubkey())?;
     Ok(program
         .request()
         .accounts(marinade_finance_accounts::EmergencyPause {
-            state: state_pubkey,
+            state: state_pubkey.clone(),
             pause_authority: state.pause_authority,
         })
-        .args(marinade_finance_instruction::Resume {})
-        .signer(pause_authority.as_ref()))
+        .args(marinade_finance_instruction::Resume {}))
 }

--- a/libs/marinade-client-rs/src/marinade/verifiers.rs
+++ b/libs/marinade-client-rs/src/marinade/verifiers.rs
@@ -37,3 +37,13 @@ pub fn verify_rent_payer(rpc_client: &RpcClient, rent_payer: Pubkey) -> anyhow::
     }
     Ok(())
 }
+
+pub fn verify_pause_authority(state: &State, pause_authority: Pubkey) -> anyhow::Result<()> {
+    if state.pause_authority != pause_authority {
+        bail!("Pause-authority {} to sign the transaction mismatches Marinade state pause authority {}",
+                pause_authority,
+                state.pause_authority
+            );
+    }
+    Ok(())
+}

--- a/libs/marinade-client-rs/src/marinade/verifiers.rs
+++ b/libs/marinade-client-rs/src/marinade/verifiers.rs
@@ -6,9 +6,9 @@ use solana_sdk::system_program;
 
 pub fn verify_manager_authority(
     state: &State,
-    validator_manager_authority: Pubkey,
+    validator_manager_authority: &Pubkey,
 ) -> anyhow::Result<()> {
-    if state.validator_system.manager_authority != validator_manager_authority {
+    if state.validator_system.manager_authority != *validator_manager_authority {
         bail!("Validator-manager-authority {} to sign the transaction mismatches Marinade state system manager authority {}",
                 validator_manager_authority,
                 state.validator_system.manager_authority
@@ -17,8 +17,8 @@ pub fn verify_manager_authority(
     Ok(())
 }
 
-pub fn verify_admin_authority(state: &State, admin_authority: Pubkey) -> anyhow::Result<()> {
-    if state.admin_authority != admin_authority {
+pub fn verify_admin_authority(state: &State, admin_authority: &Pubkey) -> anyhow::Result<()> {
+    if state.admin_authority != *admin_authority {
         bail!("Admin-authority {} signing the transaction mismatches Marinade state admin authority: {}",
                 admin_authority,
                 state.admin_authority
@@ -27,8 +27,8 @@ pub fn verify_admin_authority(state: &State, admin_authority: Pubkey) -> anyhow:
     Ok(())
 }
 
-pub fn verify_rent_payer(rpc_client: &RpcClient, rent_payer: Pubkey) -> anyhow::Result<()> {
-    let rent_account = rpc_client.get_account(&rent_payer)?;
+pub fn verify_rent_payer(rpc_client: &RpcClient, rent_payer: &Pubkey) -> anyhow::Result<()> {
+    let rent_account = rpc_client.get_account(rent_payer)?;
     if rent_account.owner != system_program::ID {
         bail!(
             "Provided rent payer {} address must be a system account",
@@ -38,8 +38,8 @@ pub fn verify_rent_payer(rpc_client: &RpcClient, rent_payer: Pubkey) -> anyhow::
     Ok(())
 }
 
-pub fn verify_pause_authority(state: &State, pause_authority: Pubkey) -> anyhow::Result<()> {
-    if state.pause_authority != pause_authority {
+pub fn verify_pause_authority(state: &State, pause_authority: &Pubkey) -> anyhow::Result<()> {
+    if &state.pause_authority != pause_authority {
         bail!("Pause-authority {} to sign the transaction mismatches Marinade state pause authority {}",
                 pause_authority,
                 state.pause_authority

--- a/libs/marinade-common-cli/Cargo.toml
+++ b/libs/marinade-common-cli/Cargo.toml
@@ -11,3 +11,4 @@ solana-sdk = "1.14.18"
 solana-clap-utils = "1.14.18"
 solana-cli-config = "1.14.18"
 solana-remote-wallet = "1.14.18"
+dynsigner = {path = "../dynsigner"}

--- a/libs/marinade-common-cli/src/lib.rs
+++ b/libs/marinade-common-cli/src/lib.rs
@@ -1,4 +1,3 @@
 #![cfg_attr(not(debug_assertions), deny(warnings))]
-
 pub mod config_args;
 pub mod matchers;

--- a/libs/marinade-common-cli/src/matchers.rs
+++ b/libs/marinade-common-cli/src/matchers.rs
@@ -1,5 +1,6 @@
 use anyhow::anyhow;
 use clap::ArgMatches;
+use dynsigner::PubkeyOrSigner;
 use log::debug;
 use solana_clap_utils::input_parsers::pubkey_of_signer;
 use solana_clap_utils::keypair::signer_from_path;
@@ -7,7 +8,6 @@ use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signer::Signer;
 use std::{str::FromStr, sync::Arc};
-use dynsigner::PubkeyOrSigner;
 
 // Getting signer from the matched name as the keypair path argument, or returns the default signer
 pub fn signer_from_path_or_default(


### PR DESCRIPTION
Main Marinade contract `liquid-staking-program` was upgraded from the branch `anchor-0.27`
https://github.com/marinade-finance/liquid-staking-program/tree/anchor-0.27

https://explorer.solana.com/tx/3T1qXqzTXjCMK7MQaAPP5y2ux5q27NkRXhYvkZ56K51oEdZ1kq8VqqYfDrbkYkoyUSaq3V4ay8yPVHie9vicUBFt

This update consists the changes to align with the new program.