### PR TITLE
Retry on blockhash not found

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "libs/*"
 ]
+resolver = "2"
 
 [profile.release]
 lto = true

--- a/libs/marinade-common-cli/src/config_args.rs
+++ b/libs/marinade-common-cli/src/config_args.rs
@@ -147,3 +147,32 @@ pub fn print_only_arg<'a, 'b>() -> Arg<'a, 'b> {
         .takes_value(false)
         .help(PRINT_ONLY_ARG.help)
 }
+
+pub const WITH_COMPUTE_UNIT_PRICE_ARG: ArgConstant<'static> = ArgConstant {
+    name: "with_compute_unit_price",
+    long: "with-compute-unit-price",
+    help: "Set compute unit price for transaction, in increments of 0.000001 lamports per compute unit.",
+};
+pub fn with_compute_unit_price<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name(WITH_COMPUTE_UNIT_PRICE_ARG.name)
+        .value_name("COMPUTE-UNIT-PRICE")
+        .takes_value(true)
+        .long(WITH_COMPUTE_UNIT_PRICE_ARG.long)
+        .help(WITH_COMPUTE_UNIT_PRICE_ARG.help)
+        .default_value("0")
+}
+
+pub const BLOCKHASH_NOT_FOUND_RETRIES_ARG: ArgConstant<'static> = ArgConstant {
+    name: "blockhash_not_found_retries",
+    long: "blockhash-not-found-retries",
+    help: "Number of retries to get a blockhash when exception BlockhashNotFound is thrown on execution.",
+};
+
+pub fn blockhash_not_found_retries_arg<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name(BLOCKHASH_NOT_FOUND_RETRIES_ARG.name)
+        .long(BLOCKHASH_NOT_FOUND_RETRIES_ARG.long)
+        .value_name("NUMBER")
+        .takes_value(true)
+        .help(BLOCKHASH_NOT_FOUND_RETRIES_ARG.help)
+        .default_value("0")
+}

--- a/libs/marinade-common-cli/src/matchers.rs
+++ b/libs/marinade-common-cli/src/matchers.rs
@@ -144,9 +144,29 @@ pub fn pubkey_or_signer(
     })
 }
 
+pub fn match_u16(matches: &ArgMatches<'_>, name: &str) -> anyhow::Result<u16> {
+    crate::matchers::match_u16_option(matches, name)?
+        .ok_or_else(|| anyhow::Error::msg(format!("match_u16: argument '{}' missing", name)))
+}
+
+pub fn match_u16_option(matches: &ArgMatches<'_>, name: &str) -> anyhow::Result<Option<u16>> {
+    if let Some(value) = matches.value_of(name) {
+        let value = u16::from_str(value).map_err(|e| {
+            anyhow!(
+                "Failed to convert argument {} of value {} to u16: {:?}",
+                name,
+                value,
+                e
+            )
+        })?;
+        return Ok(Some(value));
+    }
+    Ok(None)
+}
+
 pub fn match_u32(matches: &ArgMatches<'_>, name: &str) -> anyhow::Result<u32> {
     match_u32_option(matches, name)?
-        .ok_or_else(|| anyhow::Error::msg(format!("argument '{}' missing", name)))
+        .ok_or_else(|| anyhow::Error::msg(format!("match_u32: argument '{}' missing", name)))
 }
 
 pub fn match_u32_option(matches: &ArgMatches<'_>, name: &str) -> anyhow::Result<Option<u32>> {
@@ -166,7 +186,7 @@ pub fn match_u32_option(matches: &ArgMatches<'_>, name: &str) -> anyhow::Result<
 
 pub fn match_u64(matches: &ArgMatches<'_>, name: &str) -> anyhow::Result<u64> {
     match_u64_option(matches, name)?
-        .ok_or_else(|| anyhow::Error::msg(format!("argument '{}' missing", name)))
+        .ok_or_else(|| anyhow::Error::msg(format!("match_u64: argument '{}' missing", name)))
 }
 
 pub fn match_u64_option(matches: &ArgMatches<'_>, name: &str) -> anyhow::Result<Option<u64>> {
@@ -186,7 +206,7 @@ pub fn match_u64_option(matches: &ArgMatches<'_>, name: &str) -> anyhow::Result<
 
 pub fn match_f64(matches: &ArgMatches<'_>, name: &str) -> anyhow::Result<f64> {
     match_f64_option(matches, name)?
-        .ok_or_else(|| anyhow::Error::msg(format!("argument '{}' missing", name)))
+        .ok_or_else(|| anyhow::Error::msg(format!("match_f64: argument '{}' missing", name)))
 }
 
 pub fn match_f64_option(matches: &ArgMatches<'_>, name: &str) -> anyhow::Result<Option<f64>> {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.69.0"


### PR DESCRIPTION
Adding functionality to retry transaction execution on blockhash not found error.
Useful for tx retry for CLI.

I'm going to merge this but it will be under testing at marcrank.