### PR TITLE
Simulate to work with builder

### DIFF
--- a/libs/marinade-client-rs/src/marinade/verifiers.rs
+++ b/libs/marinade-client-rs/src/marinade/verifiers.rs
@@ -9,7 +9,7 @@ pub fn verify_manager_authority(
     validator_manager_authority: &Pubkey,
 ) -> anyhow::Result<()> {
     if state.validator_system.manager_authority != *validator_manager_authority {
-        bail!("Validator-manager-authority {} to sign the transaction mismatches Marinade state system manager authority {}",
+        bail!("verify_manager_authority: validator-manager-authority {} to sign the transaction mismatches Marinade state system manager authority {}",
                 validator_manager_authority,
                 state.validator_system.manager_authority
             );
@@ -19,7 +19,7 @@ pub fn verify_manager_authority(
 
 pub fn verify_admin_authority(state: &State, admin_authority: &Pubkey) -> anyhow::Result<()> {
     if state.admin_authority != *admin_authority {
-        bail!("Admin-authority {} signing the transaction mismatches Marinade state admin authority: {}",
+        bail!("verify_admin_authority: admin-authority {} signing the transaction mismatches Marinade state admin authority: {}",
                 admin_authority,
                 state.admin_authority
             );
@@ -31,7 +31,7 @@ pub fn verify_rent_payer(rpc_client: &RpcClient, rent_payer: &Pubkey) -> anyhow:
     let rent_account = rpc_client.get_account(rent_payer)?;
     if rent_account.owner != system_program::ID {
         bail!(
-            "Provided rent payer {} address must be a system account",
+            "verify_rent_payer: provided rent payer {} address must be a system account",
             rent_payer
         )
     }
@@ -40,7 +40,7 @@ pub fn verify_rent_payer(rpc_client: &RpcClient, rent_payer: &Pubkey) -> anyhow:
 
 pub fn verify_pause_authority(state: &State, pause_authority: &Pubkey) -> anyhow::Result<()> {
     if &state.pause_authority != pause_authority {
-        bail!("Pause-authority {} to sign the transaction mismatches Marinade state pause authority {}",
+        bail!("verify_pause_authority: pause-authority {} to sign the transaction mismatches Marinade state pause authority {}",
                 pause_authority,
                 state.pause_authority
             );

--- a/libs/marinade-client-rs/src/transactions/prepared_transaction.rs
+++ b/libs/marinade-client-rs/src/transactions/prepared_transaction.rs
@@ -42,6 +42,18 @@ impl PreparedTransaction {
         Ok(&self.transaction)
     }
 
+    pub fn partial_sign(&mut self, recent_blockhash: Hash) -> &Transaction {
+        self.transaction.partial_sign(
+            &self
+                .signers
+                .iter()
+                .map(|arc| arc.as_ref())
+                .collect::<Vec<_>>(),
+            recent_blockhash,
+        );
+        &self.transaction
+    }
+
     pub fn into_signed(mut self, recent_blockhash: Hash) -> Result<Transaction, SignerError> {
         self.sign(recent_blockhash)?;
         Ok(self.transaction)


### PR DESCRIPTION
An adjustment to make working the `simulate` call with pubkeys - i.e., when user provides pubkey instead of keypair of some admin or other wallet and we want to check simulation without verifying signatures (as signature verification fails when we provided not keypair but pubkey)