### PR TITLE
[gh] comment version [trivial]

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Marinade Common RS CLI
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Install libudev


### PR DESCRIPTION
Not sure why but PR https://github.com/marinade-finance/marinade-common-rs-cli/pull/22 has not updated action tag version